### PR TITLE
show pins nearby on the root page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'aws-sdk', '~> 1.20.0'
 gem 'masonry-rails', '~> 0.2.0'
 gem 'will_paginate', '~> 3.0.6'
 gem 'will_paginate-bootstrap'
+gem 'geocoder'
 
 
 group :development, :test do 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
       warden (~> 1.2.3)
     erubis (2.7.0)
     execjs (2.2.2)
+    geocoder (1.2.7)
     hike (1.2.3)
     i18n (0.6.11)
     jbuilder (2.2.5)
@@ -159,6 +160,7 @@ DEPENDENCIES
   bootstrap-sass
   coffee-rails (~> 4.0.0)
   devise (~> 3.1.0.rc2)
+  geocoder
   jbuilder (~> 2.0)
   jquery-rails
   jquery-turbolinks

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.for(:sign_up) << :name
-    devise_parameter_sanitizer.for(:account_update) << :name
-end
+    devise_parameter_sanitizer.for(:account_update) << [:name, :address]
+  end
 
 end

--- a/app/controllers/pins_controller.rb
+++ b/app/controllers/pins_controller.rb
@@ -4,7 +4,8 @@ class PinsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 
   def index
-    @pins = Pin.all.order("created_at DESC").paginate(:page => params[:page], :per_page => 3)
+    # @pins = Pin.all.order("created_at DESC").paginate(:page => params[:page], :per_page => 3)
+    @pins = Pin.near(current_user.address).order("created_at DESC").paginate(:page => params[:page], :per_page => 3)
   end
 
   def show
@@ -52,7 +53,7 @@ class PinsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def pin_params
-      params.require(:pin).permit(:description, :image)
+      params.require(:pin).permit(:description, :image, :address)
     end
 
 

--- a/app/models/pin.rb
+++ b/app/models/pin.rb
@@ -5,5 +5,7 @@ class Pin < ActiveRecord::Base
 	validates :description, presence: true
 	validates :image, presence: true
 
+  geocoded_by :address
+  after_validation :geocode 
 end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,10 @@ class User < ActiveRecord::Base
 
   validates :name, presence: true
 
-  after_create:send_notification
+  after_create :send_notification
+
+  geocoded_by :address
+  after_validation :geocode 
 
   def send_notification
   	AdminMailer.new_user(self).deliver

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -13,6 +13,11 @@
        <%= f.text_field :name, class: "form-control", :autofocus => true %>
      </div>
 
+     <div class="form-group">
+        <%= f.label :address %>
+        <%= f.text_field :address, class: "form-control", :autofocus => true %>
+      </div>
+
       <div class="form-group">
         <%= f.label :email %>
         <%= f.email_field :email, class: "form-control", :autofocus => true %>

--- a/app/views/pins/_form.html.erb
+++ b/app/views/pins/_form.html.erb
@@ -20,6 +20,12 @@
     <%= f.label :description %>
     <%= f.text_field :description, class: "form-control" %>
   </div>
+
+  <div class="form-group">
+    <%= f.label :address %>
+    <%= f.text_field :address, class: "form-control", placeholder: "E.g. 'Eiffel Tower, Paris, FR'" %>
+  </div>
+
   <div class="form-group">
     <%= f.submit class: "btn btn-primary" %>
   </div>

--- a/db/migrate/20150312084722_add_latitude_and_longitude_to_pins.rb
+++ b/db/migrate/20150312084722_add_latitude_and_longitude_to_pins.rb
@@ -1,0 +1,7 @@
+class AddLatitudeAndLongitudeToPins < ActiveRecord::Migration
+  def change
+    add_column :pins, :address, :string
+    add_column :pins, :latitude, :float
+    add_column :pins, :longitude, :float
+  end
+end

--- a/db/migrate/20150312090534_add_latitude_and_longitude_to_users.rb
+++ b/db/migrate/20150312090534_add_latitude_and_longitude_to_users.rb
@@ -1,0 +1,7 @@
+class AddLatitudeAndLongitudeToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :latitude, :float
+    add_column :users, :longitude, :float
+    add_column :users, :address, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150101223103) do
+ActiveRecord::Schema.define(version: 20150312090534) do
 
   create_table "pins", force: true do |t|
     t.string   "description"
@@ -22,6 +22,9 @@ ActiveRecord::Schema.define(version: 20150101223103) do
     t.string   "image_content_type"
     t.integer  "image_file_size"
     t.datetime "image_updated_at"
+    t.string   "address"
+    t.float    "latitude"
+    t.float    "longitude"
   end
 
   add_index "pins", ["user_id"], name: "index_pins_on_user_id"
@@ -40,6 +43,9 @@ ActiveRecord::Schema.define(version: 20150101223103) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "name"
+    t.float    "latitude"
+    t.float    "longitude"
+    t.string   "address"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
1. Geocoder gem
2. Address, latitude, longitude columns in User and Pin models.
   Workflow:
   User enters his address in the account settings. Pinner-User sets the address for the pin that he creates. When user gets to the home page he sees not all the pins but only the pins that are near his location.

Please have a look and contact me if there will be any questions.
Have a nice day!
