### PR TITLE
pins are dependent: :destroy to users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ActiveRecord::Base
 
   acts_as_marker
 
-  has_many :pins
+  has_many :pins, dependent: :destroy
 
   validates_presence_of :name, :zip
 


### PR DESCRIPTION
Bug fix. There shouldn't be any pins without owning users.
